### PR TITLE
Less import overhead

### DIFF
--- a/src/global/src/main.tf
+++ b/src/global/src/main.tf
@@ -64,5 +64,5 @@ module "remote_backend" {
 module "s3_datalake" {
   source                  = "./modules/datalake"
   bucket_name             = "spotifydb-datalake"
-  import_lambda_role_arns = "${data.terraform_remote_state.import_remote_state.outputs.lambda_role_arns}"
+  import_lambda_role_arns = "${data.terraform_remote_state.import_remote_state.outputs.producer_arns}"
 }

--- a/src/microservices/import/src/main.tf
+++ b/src/microservices/import/src/main.tf
@@ -34,47 +34,5 @@ resource "aws_s3_bucket" "bucket" {
 
 module "import-orchestration-topic" {
   source                   = "./modules/sns"
-  fan_out_lambda_role_arns = ["${module.import-artist-albums-lambda.lambda_role_arn}"]
-}
-
-module "import-artist-lambda" {
-  source                       = "./modules/lambda"
-  lambda_name                  = "spotifydb-artist-import-lambda"
-  lambda_file_name             = "spotifydb-artist-import-lambda.jar"
-  handler_name                 = "com.spotifydb.Handler::handleSqsMessage"
-  lambda_timeout_seconds       = "5"
-  lambda_runtime               = "java8"
-  lambda_memory_size           = "320"
-  lambda_environment_variables = "${local.import_environment_variables}"
-  entity_type                  = "artist"
-  source_bucket_name           = "${aws_s3_bucket.bucket.id}"
-  sns_topic_arn                = "${module.import-orchestration-topic.sns_topic_arn}"
-}
-
-module "import-album-lambda" {
-  source                       = "./modules/lambda"
-  lambda_name                  = "spotifydb-album-import-lambda"
-  lambda_file_name             = "spotifydb-album-import-lambda.jar"
-  handler_name                 = "com.spotifydb.Handler::handleSqsMessage"
-  lambda_timeout_seconds       = "5"
-  lambda_runtime               = "java8"
-  lambda_memory_size           = "320"
-  lambda_environment_variables = "${local.import_environment_variables}"
-  entity_type                  = "album"
-  source_bucket_name           = "${aws_s3_bucket.bucket.id}"
-  sns_topic_arn                = "${module.import-orchestration-topic.sns_topic_arn}"
-}
-
-module "import-artist-albums-lambda" {
-  source                       = "./modules/lambda"
-  lambda_name                  = "spotifydb-artist-album-fanout-lambda"
-  lambda_file_name             = "get-artist-albums.zip"
-  handler_name                 = "main"
-  lambda_timeout_seconds       = "10"
-  lambda_runtime               = "go1.x"
-  lambda_memory_size           = "128"
-  lambda_environment_variables = "${local.fan_out_environment_variables}"
-  entity_type                  = "artist"
-  source_bucket_name           = "${aws_s3_bucket.bucket.id}"
-  sns_topic_arn                = "${module.import-orchestration-topic.sns_topic_arn}"
+  #fan_out_lambda_role_arns = ["${module.import-artist-albums-lambda.lambda_role_arn}"]
 }

--- a/src/microservices/import/src/main.tf
+++ b/src/microservices/import/src/main.tf
@@ -61,7 +61,7 @@ module "import-entity-lambda" {
   lambda_runtime                 = "go1.x"
   lambda_memory_size             = "128"
   messages_per_lambda_invocation = "10"
-  lambda_environment_variables   = "${local.fan_out_environment_variables}"
+  lambda_environment_variables   = "${local.import_environment_variables}"
   entity_types                   = ["album", "artist"]
   source_bucket_name             = "${aws_s3_bucket.bucket.id}"
   sns_topic_arn                  = "${module.import-orchestration-topic.sns_topic_arn}"

--- a/src/microservices/import/src/modules/lambda/main.tf
+++ b/src/microservices/import/src/modules/lambda/main.tf
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "role_execution_policy_document" {
 resource "aws_lambda_event_source_mapping" "trigger_lambda_from_sqs" {
   event_source_arn = "${aws_sqs_queue.sqs.arn}"
   function_name    = "${aws_lambda_function.lambda.arn}"
-  batch_size       = "1"
+  batch_size       = "${var.messages_per_lambda_invocation}"
 }
 
 
@@ -95,8 +95,9 @@ data "aws_iam_policy_document" "queue_policy_document" {
 }
 
 resource "aws_sns_topic_subscription" "subscribe_sqs_to_sns" {
-  protocol      = "sqs"
-  topic_arn     = "${var.sns_topic_arn}"
-  endpoint      = "${aws_sqs_queue.sqs.arn}"
-  filter_policy = "${jsonencode(map("type", list(var.entity_type)))}"
+  protocol             = "sqs"
+  topic_arn            = "${var.sns_topic_arn}"
+  endpoint             = "${aws_sqs_queue.sqs.arn}"
+  filter_policy        = "${jsonencode(map("entity_type", var.entity_types))}"
+  raw_message_delivery = "true"
 }

--- a/src/microservices/import/src/modules/lambda/variables.tf
+++ b/src/microservices/import/src/modules/lambda/variables.tf
@@ -18,9 +18,9 @@ variable "sns_topic_arn" {
   description = "The ARN of the SNS topic that orchestrates the import process"
 }
 
-variable "entity_type" {
-  type        = "string"
-  description = "The type of entity to filter SNS messages on"
+variable "entity_types" {
+  type        = "list"
+  description = "The list of entity type strings to fiter SNS messages on"
 }
 
 variable "lambda_timeout_seconds" {
@@ -46,4 +46,9 @@ variable "lambda_file_name" {
 variable "lambda_environment_variables" {
   type        = "map"
   description = "The environment variables to provide to the lamdba"
+}
+
+variable "messages_per_lambda_invocation" {
+  type        = "string"
+  description = "Integer defining how many sqs messages should be processed at a time"
 }

--- a/src/microservices/import/src/modules/sns/main.tf
+++ b/src/microservices/import/src/modules/sns/main.tf
@@ -2,20 +2,20 @@ resource "aws_sns_topic" "import_data_topic" {
   name = "import-data-topic"
 }
 
-# data "aws_iam_policy_document" "topic_policy_document" {
-#   version = "2012-10-17"
-#   statement {
-#     effect    = "Allow"
-#     actions   = ["sns:Publish"]
-#     resources = ["${aws_sns_topic.import_data_topic.arn}"]
-#     principals {
-#       type        = "AWS"
-#       identifiers = "${var.fan_out_lambda_role_arns}"
-#     }
-#   }
-# }
+data "aws_iam_policy_document" "topic_policy_document" {
+  version = "2012-10-17"
+  statement {
+    effect    = "Allow"
+    actions   = ["sns:Publish"]
+    resources = ["${aws_sns_topic.import_data_topic.arn}"]
+    principals {
+      type        = "AWS"
+      identifiers = "${var.publisher_arns}"
+    }
+  }
+}
 
-# resource "aws_sns_topic_policy" "topic_policy" {
-#   arn    = "${aws_sns_topic.import_data_topic.arn}"
-#   policy = "${data.aws_iam_policy_document.topic_policy_document.json}"
-# }
+resource "aws_sns_topic_policy" "topic_policy" {
+  arn    = "${aws_sns_topic.import_data_topic.arn}"
+  policy = "${data.aws_iam_policy_document.topic_policy_document.json}"
+}

--- a/src/microservices/import/src/modules/sns/main.tf
+++ b/src/microservices/import/src/modules/sns/main.tf
@@ -2,20 +2,20 @@ resource "aws_sns_topic" "import_data_topic" {
   name = "import-data-topic"
 }
 
-data "aws_iam_policy_document" "topic_policy_document" {
-  version = "2012-10-17"
-  statement {
-    effect    = "Allow"
-    actions   = ["sns:Publish"]
-    resources = ["${aws_sns_topic.import_data_topic.arn}"]
-    principals {
-      type        = "AWS"
-      identifiers = "${var.fan_out_lambda_role_arns}"
-    }
-  }
-}
+# data "aws_iam_policy_document" "topic_policy_document" {
+#   version = "2012-10-17"
+#   statement {
+#     effect    = "Allow"
+#     actions   = ["sns:Publish"]
+#     resources = ["${aws_sns_topic.import_data_topic.arn}"]
+#     principals {
+#       type        = "AWS"
+#       identifiers = "${var.fan_out_lambda_role_arns}"
+#     }
+#   }
+# }
 
-resource "aws_sns_topic_policy" "topic_policy" {
-  arn    = "${aws_sns_topic.import_data_topic.arn}"
-  policy = "${data.aws_iam_policy_document.topic_policy_document.json}"
-}
+# resource "aws_sns_topic_policy" "topic_policy" {
+#   arn    = "${aws_sns_topic.import_data_topic.arn}"
+#   policy = "${data.aws_iam_policy_document.topic_policy_document.json}"
+# }

--- a/src/microservices/import/src/modules/sns/variables.tf
+++ b/src/microservices/import/src/modules/sns/variables.tf
@@ -1,4 +1,4 @@
-variable "fan_out_lambda_role_arns" {
-  type        = "list"
-  description = "The ARNs of the IAM roles for the lambdas that are allowed to publish to SNS"
-}
+# variable "fan_out_lambda_role_arns" {
+#   type        = "list"
+#   description = "The ARNs of the IAM roles for the lambdas that are allowed to publish to SNS"
+# }

--- a/src/microservices/import/src/modules/sns/variables.tf
+++ b/src/microservices/import/src/modules/sns/variables.tf
@@ -1,4 +1,4 @@
-# variable "fan_out_lambda_role_arns" {
-#   type        = "list"
-#   description = "The ARNs of the IAM roles for the lambdas that are allowed to publish to SNS"
-# }
+variable "publisher_arns" {
+  type        = "list"
+  description = "The ARNs of resources that are allowed to publish to the topic"
+}

--- a/src/microservices/import/src/outputs.tf
+++ b/src/microservices/import/src/outputs.tf
@@ -1,3 +1,3 @@
-output "lambda_role_arns" {
-  value = ["${module.import-album-lambda.lambda_role_arn}", "${module.import-artist-lambda.lambda_role_arn}"]
-}
+# output "lambda_role_arns" {
+#   value = ["${module.import-album-lambda.lambda_role_arn}", "${module.import-artist-lambda.lambda_role_arn}"]
+# }

--- a/src/microservices/import/src/outputs.tf
+++ b/src/microservices/import/src/outputs.tf
@@ -1,3 +1,4 @@
-# output "lambda_role_arns" {
-#   value = ["${module.import-album-lambda.lambda_role_arn}", "${module.import-artist-lambda.lambda_role_arn}"]
-# }
+output "producer_arns" {
+  value       = ["${module.import-entity-lambda.lambda_role_arn}"]
+  description = "The ARNs of resources that should be granted PUT access to the datalake"
+}


### PR DESCRIPTION
Product of consolidating import functions into two lambdas: one that saves entities to the datalake and another that fans out to get related entitites. For example, when an album is being added the fan out lambda will cause the system to save detailed track logic. This differs from the previous approach that had one lambda per entity.